### PR TITLE
Allow off-origin links to be opened by the sidebar

### DIFF
--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -43,7 +43,7 @@
           allow-top-navigation
           allow-top-navigation-by-user-activation
         -->
-        <iframe id="browser-iframe" src="about:blank" sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-scripts"></iframe>
+        <iframe id="browser-iframe" src="about:blank" sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-scripts allow-popups"></iframe>
       </div>
       <label class="site-request" for="desktop">
         <span>Request desktop site</span>


### PR DESCRIPTION
The sidebar always tries to open links elsewhere, and this seems to trigger the allow-popups permission. This isn't a complete solution, as the links still don't open where we want, but at least they open.