### PR TITLE
Fix #120, add an add-on icon

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -3,6 +3,10 @@
     "name": "Side View",
     "version": "{{version}}{{timestamp}}",
     "description": "{{description}}",
+    "icons": {
+      "48": "side-view.svg",
+      "96": "side-view.svg"
+    }
     "author": "{{{author}}}",
     "homepage_url": "{{{homepage}}}",
     "applications": {


### PR DESCRIPTION
Note the documentation specifically suggests assigning an SVG icon to both sizes: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/icons#SVG