### PR TITLE
Fix #153, open sidebar from popup

### DIFF
--- a/addon/sidebar.js
+++ b/addon/sidebar.js
@@ -1,26 +1,9 @@
-
-
-function sendEvent(args) {
-  // We bucket to the nearest 50px:
-  args.cd1 = Math.round(window.innerWidth / 50) * 50;
-  args.type = "sendEvent";
-  browser.runtime.sendMessage(args);
-}
-
-function element(selector) {
-  return document.querySelector(selector);
-}
-
-element(".feedback-button").addEventListener("click", () => {
-  sendEvent({
-    ec: "interface",
-    ea: "button-click",
-    el: "feedback",
-  });
-});
-
 async function init() {
   await browser.sideview.increaseSidebarMaxWidth();
+  await browser.runtime.sendMessage({
+    type: "sidebarOpened",
+    width: Math.round(window.innerWidth / 50) * 50,
+  });
 }
 
 init();


### PR DESCRIPTION
- Also removes a bunch of messages/handlers that aren't applicable.
- Trim sidebar.js down to minimal code
- Send all requests to open pages to the background
- Cache known sidebar width for metrics