### PR TITLE
Fix #216 Allow the wide sidebar on new windows created after side view was loaded.

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -157,6 +157,7 @@ async function openUrl(url) {
   }).catch((error) => {
     // If the popup is not open this gives an error, but we don't care
   });
+  await browser.sideview.increaseSidebarMaxWidth();
   browser.sidebarAction.setPanel({panel: url});
 }
 


### PR DESCRIPTION
increaseSidebarMaxWidth is idempotent, so we can just call it every time the browser action is clicked.