### PR TITLE
Fix #197, make the default desktop sites update even if you've set your own custom desktop sites

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -10,12 +10,15 @@ const USER_AGENT = `Mozilla/5.0 (Android 4.4; Mobile; rv:${FIREFOX_VERSION}) Gec
 // Chrome for Android:
 //   Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
 
+// If you update DEFAULT_DESKTOP_SITES you should also increment DEFAULT_DESKTOP_VERSION
 const DEFAULT_DESKTOP_SITES = [
   "www.youtube.com",
   "www.metacafe.com",
   "myspace.com",
   "imgur.com",
 ];
+
+const DEFAULT_DESKTOP_VERSION = 1;
 
 const MAX_RECENT_TABS = 5;
 const manifest = browser.runtime.getManifest();
@@ -225,7 +228,7 @@ async function toggleDesktop() {
   // back to the previous URL:
   browser.sidebarAction.setPanel({panel: "about:blank"});
   openUrl(sidebarUrl);
-  await browser.storage.sync.set({desktopHostnames});
+  await browser.storage.sync.set({desktopHostnames, defaultDesktopVersion: DEFAULT_DESKTOP_VERSION});
 }
 
 let recentTabs = [];
@@ -284,14 +287,16 @@ async function turnOffPrivateWarning() {
 }
 
 async function init() {
-  const result = await browser.storage.sync.get(["desktopHostnames", "recentTabs", "hasSeenPrivateWarning"]);
+  const result = await browser.storage.sync.get(["desktopHostnames", "defaultDesktopVersion", "recentTabs", "hasSeenPrivateWarning"]);
   if (!result.desktopHostnames) {
     desktopHostnames = {};
+  } else {
+    desktopHostnames = result.desktopHostnames;
+  }
+  if (!result.defaultDesktopVersion || result.defaultDesktopVersion < DEFAULT_DESKTOP_VERSION) {
     for (let hostname of DEFAULT_DESKTOP_SITES) {
       desktopHostnames[hostname] = true;
     }
-  } else {
-    desktopHostnames = result.desktopHostnames;
   }
   recentTabs = result.recentTabs || [];
   hasSeenPrivateWarning = result.hasSeenPrivateWarning;


### PR DESCRIPTION
Note that this will wipe out any overrides of the default sites themselves, but otherwise this lets us update the site list in later releases.