### PR TITLE
Fix 226 If the WebExtension API Experiment does not load, just ignore…

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -160,7 +160,9 @@ async function openUrl(url) {
   }).catch((error) => {
     // If the popup is not open this gives an error, but we don't care
   });
-  await browser.sideview.increaseSidebarMaxWidth();
+  if (browser.sideview !== undefined) {
+    await browser.sideview.increaseSidebarMaxWidth();
+  }
   browser.sidebarAction.setPanel({panel: url});
 }
 

--- a/addon/sidebar.js
+++ b/addon/sidebar.js
@@ -3,7 +3,6 @@ function element(selector) {
 }
 
 async function init() {
-  await browser.sideview.increaseSidebarMaxWidth();
   await browser.runtime.sendMessage({
     type: "sidebarOpened",
     width: Math.round(window.innerWidth / 50) * 50,
@@ -18,6 +17,9 @@ async function init() {
   element("#give-feedback").onclick = () => {
     window.open("https://qsurvey.mozilla.com/s3/Test-Pilot-Side-View?ref=sidebar");
   };
+  if (browser.sideview !== undefined) {
+    await browser.sideview.increaseSidebarMaxWidth();
+  }
 }
 
 init();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "side-view",
   "description": "Open a mobile view of a page in the sidebar",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Mozilla (https://mozilla.org/)",
   "bugs": {
     "url": "https://github.com/mozilla/side-view/issues"


### PR DESCRIPTION
… it and continue.

In this case, side view remains usable instead of just breaking. The sidebar will not be able to be resized, but that's a much more minor bug than the entire thing being broken.