### PR TITLE
#206 - Adds listeners to update popup if tabs change while popup is open

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -199,6 +199,11 @@ async function init() {
     element("#private-warning").style.display = "";
   }
   updateHome();
+
+  // Listen for tab changes to update while popup is still open
+  for (let eventName of rerenderEvents) {
+    browser.tabs[eventName].addListener(updateHome);
+  }
 }
 
 init();


### PR DESCRIPTION
Addresses #206. Adds all the tab-specific listeners so that Current Tabs is updated if tabs are changed while the popup is open.

Six listeners seems like a ton of overhead to address a fairly specific edge case -- either the user is opening tabs and navigating to sites with their keyboard while the popup is open, or they have popup auto-hide disabled (which doesn't seem like a case worth addressing).

Wanted to get others' thoughts on if #206 justifies so much overhead.