### PR TITLE
Change popup Recent Tabs wording to "Recent"

### DIFF
--- a/addon/popup.html
+++ b/addon/popup.html
@@ -16,7 +16,7 @@
       </div>
       <div class="tabs-wrapper">
         <section class="tabs-section" id="recent-tabs">
-          <h2 class="tabs-section__title">Recent Tabs</h2>
+          <h2 class="tabs-section__title">Recent</h2>
           <ul id="recent-tabs-list" class="tabs-section__list" role="navigation">
             <!--TODO: Populate this section from localstorage -->
           </ul>


### PR DESCRIPTION
Resolves the confusion around #242. The wording "Recent Tabs" suggested that Recent Tabs could be a list of recently closed tabs. 

@fzzzy suggested a change to "Recent", which makes more sense in the context of the Side View popup. It also differentiates "Recent Tabs" from "Current Tabs" which _is_ a list of tabs as they relate to the browser, rather than as they relate to Side View.