### PR TITLE
Added listener to resize sidebar maxwidth on new window

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -305,6 +305,11 @@ async function init() {
   if (!hasSeenPrivateWarning) {
     browser.tabs.onUpdated.addListener(privateWarningOnUpdated);
   }
+  if (browser.sideview !== undefined) {
+    browser.windows.onCreated.addListener(async (window) => {
+      await browser.sideview.increaseSidebarMaxWidth();
+    });
+  }
 }
 
 init();


### PR DESCRIPTION
Addresses #234 #235. Sidebar wasn't resizing since sidebar.js init() isn't called when a new window is opened.

**Resolution**: Adds listener in background.js to resize sidebar maxwidth on new window opening per @fzzzy's recommendation in #235. 