### PR TITLE
Adds a dismiss button to remove Recent tabs (#177)

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -182,6 +182,8 @@ browser.runtime.onMessage.addListener(async (message) => {
     if (!windowInfo.incognito) {
       addRecentTab(message);
     }
+  } else if (message.type === "dismissTab") {
+    dismissRecentTab(message.index);
   } else if (message.type === "getRecentAndDesktop") {
     let isDesktop = false;
     if (sidebarUrl) {
@@ -248,6 +250,24 @@ async function addRecentTab(tabInfo) {
     if (String(error).includes("Could not establish connection")) {
       // We're just speculatively sending messages to the popup, it might not be open,
       // and that is fine
+    } else {
+      console.error("Got updating recent tabs:", String(error), error);
+    }
+  }
+  await browser.storage.sync.set({recentTabs});
+}
+
+async function dismissRecentTab(tab_index) {
+  recentTabs.splice(tab_index, 1);
+  try {
+    await browser.runtime.sendMessage({
+      type: "updateRecentTabs",
+      recentTabs
+    });
+
+  } catch (error) {
+    if (String(error).includes("Could not establish connection")) {
+      // popup speculation, as in addRecentTab()
     } else {
       console.error("Got updating recent tabs:", String(error), error);
     }

--- a/addon/images/close-16-light.svg
+++ b/addon/images/close-16-light.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="rgba(249, 249, 250, .8)" d="M9.061 8l3.47-3.47a.75.75 0 0 0-1.061-1.06L8 6.939 4.53 3.47a.75.75 0 1 0-1.06 1.06L6.939 8 3.47 11.47a.75.75 0 1 0 1.06 1.06L8 9.061l3.47 3.47a.75.75 0 0 0 1.06-1.061z"></path>
+</svg>

--- a/addon/images/close-16.svg
+++ b/addon/images/close-16.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M9.061 8l3.47-3.47a.75.75 0 0 0-1.061-1.06L8 6.939 4.53 3.47a.75.75 0 1 0-1.06 1.06L6.939 8 3.47 11.47a.75.75 0 1 0 1.06 1.06L8 9.061l3.47 3.47a.75.75 0 0 0 1.06-1.061z"></path>
+</svg>

--- a/addon/popup.css
+++ b/addon/popup.css
@@ -75,20 +75,27 @@ body {
   overflow-y: auto;
 }
 
+.tab__parent {
+  display: flex;
+  width: 100%;
+  background: #fff;
+  height: 26.5px;
+}
+
 .tab {
   align-items: center;
   border: 0;
   width: 100%;
-  background: #fff;
-  display: flex;
+  background: transparent;
   font-weight: normal;
-  height: 26.5px;
   padding-inline-start: 18px;
   padding: 4px 12px;
+  display: flex;
+  overflow: hidden;
 }
 
-.tab:hover,
-.tab:focus {
+.tab__parent:hover,
+.tab__parent:focus {
   background: #ededf0;
 }
 
@@ -102,6 +109,45 @@ body {
   flex: 0 0 16px;
   height: 16px;
   margin-inline-end: 8px;
+}
+
+.tab__dismiss {
+  border: 0;
+  background: transparent;
+  margin-top: 3.25px;
+  margin-left: auto;
+  margin-right: 10px;
+  border-radius: 10%;
+  opacity: 0;
+  height: 20px;
+  padding: 2px;
+}
+
+.tab__dismiss:hover,
+.tab__dismiss:focus {
+  background: rgba(224, 224, 225, 0.9);
+}
+
+.tab__dismiss:hover,
+.tab__dismiss:focus,
+.tab:hover + .tab__dismiss,
+.tab:focus + .tab__dismiss,
+.tab__parent:hover .tab__dismiss,
+.tab__parent:focus .tab__dismiss {
+  opacity: 100;
+}
+
+.tab__dismiss::after {
+  content: url(images/close-16.svg);  /* close symbol */
+}
+
+#panel.dark-theme .tab__dismiss:hover,
+#panel.dark-theme .tab__dismiss:focus {
+  background: --dark-theme-highlight-color;
+}
+
+#panel.dark-theme .tab__dismiss::after {
+  content: url(images/close-16-light.svg);
 }
 
 /* this is a hack if, for any reason, a site does not


### PR DESCRIPTION
Addresses #177. Adds a dismiss button to recent tabs that appears on hover. 
Adding a button to the tabs required the `anchor` element to be changed from a `button` to a clickable `div`.
Dark theming in `popup.css` depends on dark theme #239 being implemented. 