### PR TITLE
Resolves #262. Dismiss button is color corrected on dark.

### DIFF
--- a/addon/popup.css
+++ b/addon/popup.css
@@ -149,15 +149,6 @@ body {
   content: url(images/close-16.svg);  /* close symbol */
 }
 
-#panel.dark-theme .tab__dismiss:hover,
-#panel.dark-theme .tab__dismiss:focus {
-  background: --dark-theme-highlight-color;
-}
-
-#panel.dark-theme .tab__dismiss::after {
-  content: url(images/close-16-light.svg);
-}
-
 /* this is a hack if, for any reason, a site does not
 supply a favicon */
 
@@ -240,15 +231,28 @@ supply a favicon */
 /* Dark theme */
 
 #panel.dark-theme,
-#panel.dark-theme .tab {
-  background: var(--dark-theme-background-color);
+#panel.dark-theme .tab,
+#panel.dark-theme .tab__parent,
+#panel.dark-theme .tab__dismiss {
+  background-color: var(--dark-theme-background-color);
   color: var(--dark-theme-color);
 }
 
-#panel.dark-theme .tab:hover,
-#panel.dark-theme .tab:focus,
+#panel.dark-theme .tab__parent:hover,
+#panel.dark-theme .tab__parent:focus,
+#panel.dark-theme .tab__parent:hover > *,
+#panel.dark-theme .tab__parent:focus > *,
 #panel.dark-theme .separator {
-  background: var(--dark-theme-highlight-color);
+  background-color: var(--dark-theme-highlight-color);
+}
+
+#panel.dark-theme .tab__dismiss:hover,
+#panel.dark-theme .tab__dismiss:focus {
+  background-color: var(--dark-theme-background-color);
+}
+
+#panel.dark-theme .tab__dismiss::after {
+  content: url(images/close-16-light.svg);
 }
 
 #panel.dark-theme .feedback-button,


### PR DESCRIPTION
Fixes the dark theme dismiss button issues filed in #262. 

Also moved some dark theming of the dismiss button down to the rest of the dark theme CSS, and set only `background-color` instead of `background` since that's all that is needed.

Concern: what might be strange highlighting behaviour. When the user hovers over the tab, the entire background including behind the dismiss button turns `dark-theme-highlight-color`. Then, when the user hovers the dismiss button, it turns `dark-theme-background-color` so its differentiated. I looked to see if there was a precedent in the browser for this behaviour and didn't see one. This might need a future UX discussion.