### PR TITLE
Start #330, add a build step for the AMO version of Side View

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Use `npm install`, then `npm start`.
 
 To use the build intended for a [Shield Study](https://wiki.mozilla.org/Firefox/Shield/Shield_Studies) use `SHIELD=1 npm run build`
 
+To use the build intended for addons.mozilla.org (as opposed to Test Pilot) use `npm run build-amo`
+
 ## Installing manually
 
 Check out the repository. Go to `about:debugging` in Firefox, and select **Load Temporary Add-on**. Select a file in the `addon/` directory.

--- a/addon/background.js
+++ b/addon/background.js
@@ -23,12 +23,13 @@ const DEFAULT_DESKTOP_VERSION = 1;
 const MAX_RECENT_TABS = 5;
 const manifest = browser.runtime.getManifest();
 const isShield = manifest.applications.gecko.id.endsWith("shield.mozilla.org");
+const isAmo = buildSettings.isAmo;
 let sidebarUrl;
 let sidebarWidth;
 let hasSeenPrivateWarning = false;
 
 let ga;
-if (!isShield) {
+if (!isShield && !isAmo) {
   ga = new TestPilotGA({
     an: "side-view",
     aid: manifest.applications.gecko.id,
@@ -42,6 +43,9 @@ if (!isShield) {
 }
 
 async function sendEvent(args) {
+  if (isAmo) {
+    return;
+  }
   if (isShield) {
     console.info("Aborting event for Shield");
     return;

--- a/addon/buildSettings.js.tmpl
+++ b/addon/buildSettings.js.tmpl
@@ -1,3 +1,4 @@
 var buildSettings = {
-  NODE_ENV: "{{NODE_ENV}}"
+  NODE_ENV: "{{NODE_ENV}}",
+  isAmo: !!"{{IS_AMO}}"
 }

--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -18,6 +18,7 @@
         "strict_min_version": "57.0a1"
       }
     },
+    {{^IS_AMO}}
     "experiment_apis": {
       {{#SHIELD}}
       "study": {
@@ -38,12 +39,13 @@
         }
       }
     },
+    {{/IS_AMO}}
     "background": {
       "scripts": [
         "build/buildSettings.js",
-        {{^SHIELD}}
+        {{^SHIELD_OR_AMO}}
         "build/testpilot-ga.js",
-        {{/SHIELD}}
+        {{/SHIELD_OR_AMO}}
         "background.js"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "start": "npm-run-all build run",
+    "start-amo": "npm-run-all build-amo run",
     "lint": "npm-run-all lint:*",
     "lint:addon": "npm run package && addons-linter ./addon.xpi -o text --self-hosted",
     "lint:js": "eslint .",
@@ -37,9 +38,12 @@
     "build": "npm-run-all build:*",
     "build:ga": "mkdir -p addon/build && cp $(node -e 'console.log(require.resolve(\"testpilot-ga\"))') addon/build/testpilot-ga.js",
     "build:testutils": "if [[ -n \"$SHIELD\" ]] ; then copyStudyUtils ./experiment/ ; else rm -rf ./experiment/study/ ; fi",
-    "build:manifest": "node -e 'let input = JSON.parse(fs.readFileSync(\"package.json\")); input.version = input.version.slice(0, -1) + Math.floor((Date.now() - new Date(new Date().getFullYear().toString()).getTime()) / 3600000); Object.assign(input, process.env); console.log(JSON.stringify(input))' | mustache - addon/manifest.json.tmpl > addon/manifest.json",
+    "build:manifest": "node -e 'let input = JSON.parse(fs.readFileSync(\"package.json\")); input.version = input.version.slice(0, -1) + Math.floor((Date.now() - new Date(new Date().getFullYear().toString()).getTime()) / 3600000); Object.assign(input, process.env); input.SHIELD_OR_AMO = input.SHIELD || input.IS_AMO ; console.log(JSON.stringify(input))' | mustache - addon/manifest.json.tmpl > addon/manifest.json",
     "build:buildSettings": "node -e 'console.log(JSON.stringify(process.env))' | mustache - addon/buildSettings.js.tmpl > addon/build/buildSettings.js",
     "build:web-ext": "web-ext build --source-dir=addon --overwrite-dest --ignore-files '*.tmpl' && zip -r web-ext-artifacts/`ls -t1 web-ext-artifacts | head -n 1` experiment",
+    "build-amo": "npm-run-all build-amo:*",
+    "build-amo:buildSettings": "IS_AMO=1 npm-run-all build:buildSettings build:manifest",
+    "build-amo:web-ext": "web-ext build --source-dir=addon --overwrite-dest --ignore-files '*.tmpl' --ignore-files 'build/testpilot-ga.js'",
     "package": "npm run build && cp web-ext-artifacts/`ls -t1 web-ext-artifacts | head -n 1` addon.xpi",
     "run": "mkdir -p ./Profile && web-ext run --source-dir=addon -p ./Profile --browser-console --keep-profile-changes -f nightly",
     "test": "npm run lint"


### PR DESCRIPTION
This doesn't complete this, but adds `npm run build-amo` and `npm run start-amo`, and removes GA and the experiment