### PR TITLE
Fix #334 and fix #308, add badge for onboarding

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -349,8 +349,23 @@ async function increaseSidebarMaxWidth() {
   }
 }
 
+function showOnboardingBadge() {
+  browser.browserAction.setBadgeText({text: "New"});
+  browser.browserAction.setBadgeBackgroundColor({color: "#0a84ff"});
+  function onBrowserActionClick() {
+    browser.sidebarAction.open();
+    browser.browserAction.onClicked.removeListener(onBrowserActionClick);
+    browser.browserAction.setBadgeText({text: ""});
+    browser.storage.sync.set({hasBeenOnboarded: true});
+    browser.browserAction.setPopup({popup: "popup.html"});
+  }
+  // This disables the default popup action and lets us intercept the clicks:
+  browser.browserAction.setPopup({popup: ""});
+  browser.browserAction.onClicked.addListener(onBrowserActionClick);
+}
+
 async function init() {
-  const result = await browser.storage.sync.get(["desktopHostnames", "defaultDesktopVersion", "recentTabs", "hasSeenPrivateWarning"]);
+  const result = await browser.storage.sync.get(["desktopHostnames", "defaultDesktopVersion", "recentTabs", "hasSeenPrivateWarning", "hasBeenOnboarded"]);
   if (!result.desktopHostnames) {
     desktopHostnames = {};
   } else {
@@ -370,6 +385,9 @@ async function init() {
     browser.windows.onCreated.addListener(async (window) => {
       await increaseSidebarMaxWidth();
     });
+  }
+  if (!result.hasBeenOnboarded && isShield) {
+    showOnboardingBadge();
   }
 }
 

--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -54,6 +54,9 @@
       "browser_style": true
     },
     "sidebar_action": {
+      {{#SHIELD}}
+      "open_at_install": false,
+      {{/SHIELD}}
       "default_icon": "side-view.svg",
       "default_title": "Side View",
       "default_panel": "sidebar.html",


### PR DESCRIPTION
When building for Shield, this turns off the default opening of the sidebar on install. A badge is added to the toolbar button (with "New"), and on first click it will open the sidebar which will show onboarding. After clicking the button the badge will no longer be shown and the popup will appear as normal.

The badge will look like this:

<img width="40" alt="image" src="https://user-images.githubusercontent.com/44390/45715254-640f2e00-bb59-11e8-9f64-0ab86ce52b9d.png">

Note this will conflict with #336 