### PR TITLE
Only send addon_init with the startup/startup event

### DIFF
--- a/addon/shield-setup.js
+++ b/addon/shield-setup.js
@@ -18,7 +18,7 @@ this.shieldSetup = (function () {
   const LAST_LOAD_URL_LIMIT = 1000; // 1 second
 
   exports.sendShieldEvent = async function(args) {
-    if (args.ec === "startup") {
+    if (args.ec === "startup" && args.ea === "startup") {
       await shieldIsSetup;
       browser.study.sendTelemetry({message: "addon_init"});
     } else if (args.ea === "load-url") {


### PR DESCRIPTION
The code expected just one event in the startup category, but there are several related to add-on initialization. There's only one startup category AND action, so we should only send at that moment.