### PR TITLE
Fix several issues with the Shield study

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -18,6 +18,9 @@
         "strict_min_version": "57.0a1"
       }
     },
+    {{#SHIELD}}
+    "hidden": true,
+    {{/SHIELD}}
     {{^IS_AMO}}
     "experiment_apis": {
       {{#SHIELD}}

--- a/addon/shield-setup.js
+++ b/addon/shield-setup.js
@@ -149,8 +149,13 @@ this.shieldSetup = (function () {
         ],
         // maximum time that the study should run, from the first run
         expire: {
-          days: 42,
+          days: 28,
         },
+      });
+
+      browser.study.onEndStudy.addListener(async () => {
+        console.info("Uninstalling Side View study add-on (see about:studies)");
+        await browser.management.uninstallSelf();
       });
 
       _shieldIsSetupResolve();

--- a/null-addon/addon/background.js
+++ b/null-addon/addon/background.js
@@ -33,9 +33,15 @@ async function init() {
       ],
       // maximum time that the study should run, from the first run
       expire: {
-        days: 42,
+        days: 28,
       },
     });
+
+    browser.study.onEndStudy.addListener(async () => {
+      console.info("Uninstalling Side View study control add-on (see about:studies)");
+      await browser.management.uninstallSelf();
+    });
+
     browser.study.sendTelemetry({message: "addon_control_init"});
   } catch (e) {
     console.warn("Error in Shield init():", String(e), e.stack);

--- a/null-addon/addon/manifest.json
+++ b/null-addon/addon/manifest.json
@@ -4,8 +4,6 @@
   "version": "0.1",
   "description": "This is an empty add-on that has no functionality",
   "icons": {
-    // "48": "side-view.png",
-    // "96": "side-view.png"
   },
   "author": "Mozilla (https://mozilla.org/)",
   "homepage_url": "https://github.com/mozilla/side-view/",
@@ -15,6 +13,7 @@
       "strict_min_version": "57.0a1"
     }
   },
+  "hidden": true,
   "experiment_apis": {
     "study": {
       "schema": "./experiment/study/schema.json",


### PR DESCRIPTION
* Fix #391, uninstall the add-on when the experiment ends
* Fix #386, set the expiration time to 4 weeks
* Fix #385, set the add-on to be hidden in the manifest

Unfortunately I haven't been able to confirm any of these. Setting my clock ahead didn't really trigger an uninstallation, because the add-on is loaded differently during development. Seems like we'll need a signed extension to test it properly.