### PR TITLE
Remove update_url from manifest

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -12,9 +12,6 @@
     "applications": {
       "gecko": {
         "id": {{#SHIELD}}"side-view-shield@mozilla.org"{{/SHIELD}}{{^SHIELD}}"side-view@mozilla.org"{{/SHIELD}},
-        {{#SHIELD}}
-        "update_url": "https://testpilot.firefox.com/files/side-view@mozilla.org/updates.json",
-        {{/SHIELD}}
         "strict_min_version": "57.0a1"
       }
     },


### PR DESCRIPTION
This should allow Test Pilot users to automatically start picking up the AMO version of the add-on