### PR TITLE
Bump Node version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
     package:
         docker:
-            - image: circleci/node:8.9.4
+            - image: circleci/node:20.18
         steps:
             - checkout
             - restore_cache:


### PR DESCRIPTION
This should update our CI config, though we probably need to re-add the
Circle integration in GitHub.