### PR TITLE
Make side-view context menu icon compatible with dark mode

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -4,8 +4,8 @@
     "version": "{{version}}",
     "description": "{{description}}",
     "icons": {
-      "48": "side-view.png",
-      "96": "side-view.png"
+      "48": "side-view.svg",
+      "96": "side-view.svg"
     },
     "author": "{{{author}}}",
     "homepage_url": "{{{homepage}}}",

--- a/addon/side-view.svg
+++ b/addon/side-view.svg
@@ -1,1 +1,13 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><g fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="nonzero"><path d="M11 6.1c-.2-.2-.6-.2-.8 0-.2.2-.2.6 0 .8l1 1.1H4.8l1-1.1c.2-.2.2-.6 0-.8-.2-.2-.6-.2-.8 0l-1.9 2c-.2.2-.2.6 0 .8L5 10.8c.2.2.6.2.8 0 .2-.2.2-.6 0-.8l-1-1h6.4l-1 1.1c-.2.2-.2.6 0 .8.2.2.6.2.8 0L12.9 9c.2-.2.2-.6 0-.8L11 6.1z"/><path d="M13 1H3C1.3 1 0 2.4 0 4v8c0 1.7 1.3 2.9 3 2.9h10c1.7 0 3-1.2 3-2.9V4c0-1.6-1.4-3-3-3zm1.1 11c0 .6-.4 1-1 1H8v-3H7v3H3c-.6 0-1-.4-1-1V4c0-.6.4-1 1-1h4v4h1V3h5.1c.6 0 1 .4 1 1v8z"/></g></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    :root { color-scheme: light dark; }
+    path { fill: rgb(24, 25, 26); }
+    @media (prefers-color-scheme: dark) {
+      path { fill: rgba(249, 249, 250, 0.8); }
+    }
+  </style>
+  <g fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="nonzero">
+    <path d="M11 6.1c-.2-.2-.6-.2-.8 0-.2.2-.2.6 0 .8l1 1.1H4.8l1-1.1c.2-.2.2-.6 0-.8-.2-.2-.6-.2-.8 0l-1.9 2c-.2.2-.2.6 0 .8L5 10.8c.2.2.6.2.8 0 .2-.2.2-.6 0-.8l-1-1h6.4l-1 1.1c-.2.2-.2.6 0 .8.2.2.6.2.8 0L12.9 9c.2-.2.2-.6 0-.8L11 6.1z"/>
+    <path d="M13 1H3C1.3 1 0 2.4 0 4v8c0 1.7 1.3 2.9 3 2.9h10c1.7 0 3-1.2 3-2.9V4c0-1.6-1.4-3-3-3zm1.1 11c0 .6-.4 1-1 1H8v-3H7v3H3c-.6 0-1-.4-1-1V4c0-.6.4-1 1-1h4v4h1V3h5.1c.6 0 1 .4 1 1v8z"/>
+  </g>
+</svg>


### PR DESCRIPTION
Use the SVG icon by default and make it react to the user's color scheme.

Before the fix:
![Screenshot](https://github.com/user-attachments/assets/53d7fb67-3163-47b8-9911-200ca3b3a366)


After the fix:
![Screenshot](https://github.com/user-attachments/assets/89de4685-f611-414b-abb4-9d7abdb82ee2)
![Screenshot](https://github.com/user-attachments/assets/08ad8866-edcd-4640-a52a-36d729156805)


Fixes:
* https://github.com/mozilla/side-view/issues/453
* https://github.com/mozilla/side-view/issues/147
* https://github.com/mozilla/side-view/issues/477
* As well as comments in the extension page
  * https://addons.mozilla.org/en-US/firefox/addon/side-view/reviews/2199926/
  * https://addons.mozilla.org/en-US/firefox/addon/side-view/reviews/2042479/
  * ...

Inspired by:
* https://github.com/mozilla/multi-account-containers/commit/3779f86088cfb746f0f66d3fb3b9aa14a534bec1
